### PR TITLE
Deprecate in favor of broccoli-plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 This packages allows you to use Broccoli's new `.rebuild` API and still
 support the legacy `.read` interface required for older Broccoli versions.
 
+This package is **deprecated** in favor of
+[broccoli-plugin](https://github.com/broccolijs/broccoli-plugin), which
+automatically provides the legacy `.read` interface.
+
 ## Usage
 
 When defining your plugin, call `readAPICompat.wrapFactory` to add the legacy


### PR DESCRIPTION
Do we want to deprecate this?
